### PR TITLE
Update ServiceBindingRequests to work with latest Operator

### DIFF
--- a/environments/coffeeshop-dev/services/barista-kafka/base/config/service-binding-request.yaml
+++ b/environments/coffeeshop-dev/services/barista-kafka/base/config/service-binding-request.yaml
@@ -5,15 +5,16 @@ metadata:
 spec:
   # Service Binding Operator doesn't support binding across namespaces until https://github.com/redhat-developer/service-binding-operator/issues/314 is implemented.
   # Assumption: Kafka and the application are deployed to the same namespace
-  backingServiceSelector:
-    group: kafka.strimzi.io
+  backingServiceSelectors:
+  - group: kafka.strimzi.io
     kind: Kafka
     resourceRef: my-cluster
     version: v1beta1
+    id: mycluster
   customEnvVar:
     - name: KAFKA_BOOTSTRAP_SERVERS
       value: |-
-        {{- range .status.listeners -}}
+        {{- range .mycluster.status.listeners -}}
           {{- if eq .type "plain" -}}
             {{ .bootstrapServers }}
           {{- end -}}

--- a/environments/coffeeshop-dev/services/barista-kafka/base/config/service-binding-request.yaml
+++ b/environments/coffeeshop-dev/services/barista-kafka/base/config/service-binding-request.yaml
@@ -3,12 +3,6 @@ kind: ServiceBindingRequest
 metadata:
   name: barista-kafka
 spec:
-  # applicationSelector isn't needed anymore once https://github.com/redhat-developer/service-binding-operator/issues/296 is implemented
-  applicationSelector:
-    group: apps
-    resource: deployments
-    resourceRef: barista-kafka
-    version: v1
   # Service Binding Operator doesn't support binding across namespaces until https://github.com/redhat-developer/service-binding-operator/issues/314 is implemented.
   # Assumption: Kafka and the application are deployed to the same namespace
   backingServiceSelector:

--- a/environments/coffeeshop-dev/services/coffeeshop-ui/base/config/service-binding-request.yaml
+++ b/environments/coffeeshop-dev/services/coffeeshop-ui/base/config/service-binding-request.yaml
@@ -5,15 +5,16 @@ metadata:
 spec:
   # Service Binding Operator doesn't support binding across namespaces until https://github.com/redhat-developer/service-binding-operator/issues/314 is implemented.
   # Assumption: Kafka and the application are deployed to the same namespace
-  backingServiceSelector:
-    group: kafka.strimzi.io
+  backingServiceSelectors:
+  - group: kafka.strimzi.io
     kind: Kafka
     resourceRef: my-cluster
     version: v1beta1
+    id: mycluster
   customEnvVar:
     - name: MP_MESSAGING_CONNECTOR_LIBERTY_KAFKA_BOOTSTRAP_SERVERS
       value: |-
-        {{- range .status.listeners -}}
+        {{- range .mycluster.status.listeners -}}
           {{- if eq .type "plain" -}}
             {{ .bootstrapServers }}
           {{- end -}}

--- a/environments/coffeeshop-dev/services/coffeeshop-ui/base/config/service-binding-request.yaml
+++ b/environments/coffeeshop-dev/services/coffeeshop-ui/base/config/service-binding-request.yaml
@@ -3,12 +3,6 @@ kind: ServiceBindingRequest
 metadata:
   name: coffeeshop-ui-kafka
 spec:
-  # applicationSelector isn't needed anymore once https://github.com/redhat-developer/service-binding-operator/issues/296 is implemented
-  applicationSelector:
-    group: apps
-    resource: deployments
-    resourceRef: coffeeshop-ui
-    version: v1
   # Service Binding Operator doesn't support binding across namespaces until https://github.com/redhat-developer/service-binding-operator/issues/314 is implemented.
   # Assumption: Kafka and the application are deployed to the same namespace
   backingServiceSelector:


### PR DESCRIPTION
Two recent changes to the Service Binding Operator mean that the current `ServiceBindingRequest`s no longer function, and two corresponding updates are required:

1. You do not need to specify an `applicationSelector` now that https://github.com/redhat-developer/service-binding-operator/pull/350 is implemented.  In fact, you must not do so if using with Appsody/OpenLiberty operators, otherwise both are trying to manage the same resource, and get into an endless loop of updating the deployment.  (I wasn't able to identify exactly which SBO change has triggered this)
1. `backingServiceSelector` (singular) is being deprecated in favour of `backingServiceSelectors`.  This was discussed in https://github.com/redhat-developer/service-binding-operator/issues/396 and implemented in https://github.com/redhat-developer/service-binding-operator/pull/468.  In order to distinguish between backing services, you now need to give them an `id` and reference that in the Go template expression.

This PR addresses both issues.